### PR TITLE
Allow ES6 source to be directly consumed by JSPM

### DIFF
--- a/lib/hyperagent-forms.js
+++ b/lib/hyperagent-forms.js
@@ -1,0 +1,4 @@
+import LoadHook from './hyperagent-forms/hook';
+import Form from './hyperagent-forms/form';
+
+export { LoadHook, Form };

--- a/lib/hyperagent-forms/delayed.js
+++ b/lib/hyperagent-forms/delayed.js
@@ -1,3 +1,5 @@
+import {Resource} from 'hyperagent';
+
 function DelayedResource(xhr, options, data) {
   this.xhr = xhr;
   this._options = options;
@@ -9,10 +11,10 @@ function DelayedResource(xhr, options, data) {
 }
 
 DelayedResource.prototype.loadResource = function () {
-  var resource = new Hyperagent.Resource(this._options);
+  var resource = new Resource(this._options);
   resource._load(this._data);
 
   return resource;
 };
 
-export DelayedResource;
+export default DelayedResource;

--- a/lib/hyperagent-forms/form.js
+++ b/lib/hyperagent-forms/form.js
@@ -1,7 +1,5 @@
-/*global Hyperagent */
-// TODO: Figure out a way to use tv4 as AMD/ES6 module if compiled that way ...
-
-import DelayedResource from 'hyperagent-forms/delayed';
+import DelayedResource from './delayed';
+import * as Hyperagent from 'hyperagent';
 
 function Form(object, options, data) {
   // Expose relevant object attributes.
@@ -86,4 +84,4 @@ Form.factory = function (object, options) {
   return FormFactory;
 };
 
-export Form;
+export default Form;

--- a/lib/hyperagent-forms/hook.js
+++ b/lib/hyperagent-forms/hook.js
@@ -1,14 +1,15 @@
-import Form from 'hyperagent-forms/form';
+import Form from './form';
+import {LazyResource} from 'hyperagent';
 
 function LoadHook(object) {
   var forms = object._forms;
   if (!forms) {
     this.forms = {};
   } else {
-    this.forms = new Hyperagent.LazyResource(this, forms, {
+    this.forms = new LazyResource(this, forms, {
       factory: Form.factory
     });
   }
 }
 
-export LoadHook;
+export default LoadHook;

--- a/lib/hyperagentForms.js
+++ b/lib/hyperagentForms.js
@@ -1,4 +1,0 @@
-import LoadHook from 'hyperagent-forms/hook';
-import Form from 'hyperagent-forms/form';
-
-export { LoadHook, Form };

--- a/package.json
+++ b/package.json
@@ -27,5 +27,13 @@
   },
   "scripts": {
     "test": "grunt test-ci"
+  },
+  "jspm": {
+    "directories": {
+      "lib": "lib"
+    },
+    "dependencies": {
+      "hyperagent": "github:radify/hyperagent"
+    }
   }
 }


### PR DESCRIPTION
- Make imports relative
- Add jspm config that points to 'lib' dir
- Add equivalent fork of Hyperagent as dependency
